### PR TITLE
[12.0][ADD] Manage M2M export

### DIFF
--- a/pattern_import_export/README.rst
+++ b/pattern_import_export/README.rst
@@ -49,6 +49,7 @@ Contributors
 
 * Chafique Delli <chafique.delli@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
+* François Honoré (ACSONE SA/NV) <francois.honore@acsone.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/pattern_import_export/models/__init__.py
+++ b/pattern_import_export/models/__init__.py
@@ -1,4 +1,5 @@
 from . import ir_exports_select_tab
 from . import ir_exports
+from . import ir_exports_line
 from . import ir_actions
 from . import base

--- a/pattern_import_export/models/ir_exports_line.py
+++ b/pattern_import_export/models/ir_exports_line.py
@@ -1,0 +1,102 @@
+# Copyright 2020 Akretion France (http://www.akretion.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import api, exceptions, fields, models, _
+
+
+class IrExportsLine(models.Model):
+    _inherit = "ir.exports.line"
+
+    select_tab_id = fields.Many2one("ir.exports.select.tab", string="Select tab")
+    is_many2x = fields.Boolean(
+        string="Is Many2x field", compute="_compute_is_many2x", store=True
+    )
+    is_many2many = fields.Boolean(
+        string="Is Many2many field",
+        compute="_compute_is_many2many",
+        store=True,
+    )
+    related_model_id = fields.Many2one(
+        "ir.model",
+        string="Related model",
+        compute="_compute_related_model_id",
+        store=True,
+    )
+    number_occurence = fields.Integer(
+        string="# Occurence",
+        default=1,
+        help="Number of column to create to display this Many2many field.\n"
+             "Value should be >= 1",
+    )
+
+    @api.multi
+    @api.constrains('number_occurence', 'is_many2many')
+    def _constrains_number_occurence(self):
+        """
+        Constrain function for the field number_occurence.
+        Ensure the number_occurence is at least 1 when is_many2many is True.
+        :return:
+        """
+        bad_records = self.filtered(lambda r: r.is_many2many and r.number_occurence < 1)
+        if bad_records:
+            details = "\n- ".join(bad_records.mapped("display_name"))
+            message = _("Number of occurence for Many2many fields should be "
+                        "greater or equals to 1.\n"
+                        "These lines have an invalid number of "
+                        "occurence:\n- %s") % details
+            raise exceptions.ValidationError(message)
+
+    def _get_last_field(self, model, path):
+        if "/" not in path:
+            path = path + "/"
+        field, path = path.split("/", 1)
+        if path:
+            model = self.env[model]._fields[field]._related_comodel_name
+            return self._get_last_field(model, path)
+        else:
+            return field, model
+
+    @api.multi
+    @api.depends("name", "export_id", "export_id.resource")
+    def _compute_is_many2x(self):
+        for export_line in self:
+            if export_line.export_id.resource and export_line.name:
+                field, model = export_line._get_last_field(
+                    export_line.export_id.resource, export_line.name
+                )
+                if self.env[model]._fields[field].type in ["many2one", "many2many"]:
+                    export_line.is_many2x = True
+
+    @api.multi
+    @api.depends("name", "export_id", "export_id.resource", "is_many2x")
+    def _compute_is_many2many(self):
+        for export_line in self:
+            is_many2many = False
+            if export_line.is_many2x and export_line.export_id.resource and export_line.name:
+                field, model = export_line._get_last_field(
+                    export_line.export_id.resource, export_line.name
+                )
+                if self.env[model]._fields[field].type == "many2many":
+                    is_many2many = True
+            export_line.is_many2many = is_many2many
+
+    @api.multi
+    @api.depends("name")
+    def _compute_related_model_id(self):
+        for export_line in self:
+            if export_line.export_id.resource and export_line.name:
+                field, model = export_line._get_last_field(
+                    export_line.export_id.resource, export_line.name
+                )
+                related_comodel = self.env[model]._fields[field]._related_comodel_name
+                if related_comodel:
+                    comodel = self.env["ir.model"].search(
+                        [("model", "=", related_comodel)], limit=1
+                    )
+                    export_line.related_model_id = comodel.id
+
+    def _add_xlsx_constraint(self, sheet, col, ad_sheet, ad_row):
+        source = "=" + ad_sheet.name + "!$A$2:$A$" + str(ad_row + 100)
+        sheet.data_validation(
+            1, col, 1048576, col, {"validate": "list", "source": source}
+        )
+        return True

--- a/pattern_import_export/readme/CONTRIBUTORS.rst
+++ b/pattern_import_export/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Chafique Delli <chafique.delli@akretion.com>
 * Sébastien Beau <sebastien.beau@akretion.com>
+* François Honoré (ACSONE SA/NV) <francois.honore@acsone.eu>

--- a/pattern_import_export/static/description/index.html
+++ b/pattern_import_export/static/description/index.html
@@ -402,6 +402,7 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <ul class="simple">
 <li>Chafique Delli &lt;<a class="reference external" href="mailto:chafique.delli&#64;akretion.com">chafique.delli&#64;akretion.com</a>&gt;</li>
 <li>Sébastien Beau &lt;<a class="reference external" href="mailto:sebastien.beau&#64;akretion.com">sebastien.beau&#64;akretion.com</a>&gt;</li>
+<li>François Honoré (ACSONE SA/NV) &lt;<a class="reference external" href="mailto:francois.honore&#64;acsone.eu">francois.honore&#64;acsone.eu</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/pattern_import_export/views/pattern_import_export.xml
+++ b/pattern_import_export/views/pattern_import_export.xml
@@ -14,6 +14,8 @@
             </xpath>
             <xpath expr="//field[@name='field4_id']" position="after">
                 <field name="is_many2x"/>
+                <field name="is_many2many" invisible="True"/>
+                <field name="number_occurence" attrs="{'required': [('is_many2many', '=', True)], 'readonly': [('is_many2many', '!=', True)], 'invisible': [('is_many2many', '!=', True)]}"/>
                 <field name="related_model_id"/>
                 <field name="select_tab_id"/>
             </xpath>

--- a/pattern_import_export/wizard/export_with_pattern.py
+++ b/pattern_import_export/wizard/export_with_pattern.py
@@ -20,7 +20,9 @@ class ExportPatternWizard(models.Model):
     @api.multi
     def _compute_no_export_pattern(self):
         for wiz in self:
-            ir_exports = wiz.env["ir.exports"].search([("resource", "=", wiz.model)])
+            ir_exports = wiz.env["ir.exports"].search_count(
+                [("resource", "=", wiz.model)]
+            )
             if not ir_exports:
                 wiz.no_export_pattern = True
 


### PR DESCRIPTION
Issue: https://github.com/shopinvader/pattern-import-export/issues/4
Based on PR: https://github.com/shopinvader/pattern-import-export/pull/1 (please review this one first)

Manage `Many2many` fields:
- Add a `is_many2many` boolean field on `ir.exports.line`;
- Add the `number_occurence` field on `ir.exports.line`;
- During the export, (for `Many2many` fields), generate many columns as asked by `number_occurence` (using the format: `field_name + '|' + occurence`);
- Add unit test about this.