### PR TITLE
[FIX] xlsx export: always show error column

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,4 @@
 # See https://github.com/OCA/odoo-community.org/blob/master/website/Contribution/CONTRIBUTING.rst#oca_dependencies-txt
+server-ux
+server-tools
+web

--- a/pattern_import_export/models/ir_exports_line.py
+++ b/pattern_import_export/models/ir_exports_line.py
@@ -264,7 +264,7 @@ class IrExportsLine(models.Model):
                 last_item[
                     last_field
                 ] = sub_pattern_fields._get_dict_parser_for_pattern()
-        return parser
+        return (False, parser)
 
     def _get_json_parser_for_pattern(self):
-        return convert_dict(self._get_dict_parser_for_pattern())
+        return {"fields": convert_dict(self._get_dict_parser_for_pattern()[1])}

--- a/pattern_import_export/tests/test_pattern_export.py
+++ b/pattern_import_export/tests/test_pattern_export.py
@@ -12,31 +12,103 @@ class PatternCaseExport:
     def _get_data(self, pattern_config, records):
         raise NotImplementedError
 
+    def _get_expected_results(self):
+        result = {
+            "expected_header_1": [
+                ".id",
+                "name",
+                "street",
+                "country_id|code",
+                "category_id|1|name",
+            ],
+            "expected_header_1_desc": [
+                "ID",
+                "Name",
+                "Street",
+                "Country|Country Code",
+                "Tags|1|Tag Name",
+            ],
+            "expected_header_2": [".id", "name", "company_ids|1|name"],
+            "expected_header_3": [
+                ".id",
+                "name",
+                "company_ids|1|name",
+                "company_ids|2|name",
+                "company_ids|3|name",
+                "company_ids|4|name",
+                "company_ids|5|name",
+            ],
+            "expected_header_4": [
+                ".id",
+                "name",
+                "child_ids|1|.id",
+                "child_ids|1|name",
+                "child_ids|1|street",
+                "child_ids|1|country_id|code",
+                "child_ids|1|category_id|1|name",
+                "child_ids|2|.id",
+                "child_ids|2|name",
+                "child_ids|2|street",
+                "child_ids|2|country_id|code",
+                "child_ids|2|category_id|1|name",
+                "child_ids|3|.id",
+                "child_ids|3|name",
+                "child_ids|3|street",
+                "child_ids|3|country_id|code",
+                "child_ids|3|category_id|1|name",
+                "country_id|code",
+            ],
+            "expected_header_5": [
+                ".id",
+                "name",
+                "child_ids|1|.id",
+                "child_ids|1|name",
+                "child_ids|1|street",
+                "child_ids|1|country_id|code",
+                "child_ids|1|category_id|1|name",
+                "child_ids|1|category_id|2|name",
+                "child_ids|1|category_id|3|name",
+                "child_ids|1|category_id|4|name",
+                "child_ids|1|category_id|5|name",
+                "child_ids|2|.id",
+                "child_ids|2|name",
+                "child_ids|2|street",
+                "child_ids|2|country_id|code",
+                "child_ids|2|category_id|1|name",
+                "child_ids|2|category_id|2|name",
+                "child_ids|2|category_id|3|name",
+                "child_ids|2|category_id|4|name",
+                "child_ids|2|category_id|5|name",
+                "child_ids|3|.id",
+                "child_ids|3|name",
+                "child_ids|3|street",
+                "child_ids|3|country_id|code",
+                "child_ids|3|category_id|1|name",
+                "child_ids|3|category_id|2|name",
+                "child_ids|3|category_id|3|name",
+                "child_ids|3|category_id|4|name",
+                "child_ids|3|category_id|5|name",
+                "country_id|code",
+            ],
+        }
+        return result
+
+    def _assert_result_expected_equal(self, expected, actual):
+        self.assertDictEqual(expected, actual)
+
     def test_get_header1(self):
         """
         Ensure the header is correctly generated
         @return:
         """
         headers = self._get_header(self.pattern_config)
-        expected_header = [
-            ".id",
-            "name",
-            "street",
-            "country_id|code",
-            "category_id|1|name",
-        ]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(self._get_expected_results()["expected_header_1"], headers)
 
     def test_get_header1_descriptive(self):
         headers = self._get_header(self.pattern_config, use_description=True)
-        expected_header = [
-            "ID",
-            "Name",
-            "Street",
-            "Country|Country Code",
-            "Tags|1|Tag Name",
-        ]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(
+            self._get_expected_results()["expected_header_1_desc"], headers
+        )
 
     def test_get_header2(self):
         """
@@ -44,8 +116,7 @@ class PatternCaseExport:
         @return:
         """
         headers = self._get_header(self.pattern_config_m2m)
-        expected_header = [".id", "name", "company_ids|1|name"]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(self._get_expected_results()["expected_header_2"], headers)
 
     def test_get_header3(self):
         """
@@ -55,16 +126,7 @@ class PatternCaseExport:
         export_fields_m2m = self.env.ref("pattern_import_export.demo_export_m2m_line_3")
         export_fields_m2m.write({"number_occurence": 5})
         headers = self._get_header(self.pattern_config_m2m)
-        expected_header = [
-            ".id",
-            "name",
-            "company_ids|1|name",
-            "company_ids|2|name",
-            "company_ids|3|name",
-            "company_ids|4|name",
-            "company_ids|5|name",
-        ]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(self._get_expected_results()["expected_header_3"], headers)
 
     def test_get_header4(self):
         """
@@ -73,27 +135,7 @@ class PatternCaseExport:
         @return:
         """
         headers = self._get_header(self.pattern_config_o2m)
-        expected_header = [
-            ".id",
-            "name",
-            "child_ids|1|.id",
-            "child_ids|1|name",
-            "child_ids|1|street",
-            "child_ids|1|country_id|code",
-            "child_ids|1|category_id|1|name",
-            "child_ids|2|.id",
-            "child_ids|2|name",
-            "child_ids|2|street",
-            "child_ids|2|country_id|code",
-            "child_ids|2|category_id|1|name",
-            "child_ids|3|.id",
-            "child_ids|3|name",
-            "child_ids|3|street",
-            "child_ids|3|country_id|code",
-            "child_ids|3|category_id|1|name",
-            "country_id|code",
-        ]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(self._get_expected_results()["expected_header_4"], headers)
 
     def test_get_header5(self):
         """
@@ -105,39 +147,7 @@ class PatternCaseExport:
         export_fields_m2m = self.env.ref("pattern_import_export.demo_export_line_5")
         export_fields_m2m.write({"number_occurence": 5})
         headers = self._get_header(self.pattern_config_o2m)
-        expected_header = [
-            ".id",
-            "name",
-            "child_ids|1|.id",
-            "child_ids|1|name",
-            "child_ids|1|street",
-            "child_ids|1|country_id|code",
-            "child_ids|1|category_id|1|name",
-            "child_ids|1|category_id|2|name",
-            "child_ids|1|category_id|3|name",
-            "child_ids|1|category_id|4|name",
-            "child_ids|1|category_id|5|name",
-            "child_ids|2|.id",
-            "child_ids|2|name",
-            "child_ids|2|street",
-            "child_ids|2|country_id|code",
-            "child_ids|2|category_id|1|name",
-            "child_ids|2|category_id|2|name",
-            "child_ids|2|category_id|3|name",
-            "child_ids|2|category_id|4|name",
-            "child_ids|2|category_id|5|name",
-            "child_ids|3|.id",
-            "child_ids|3|name",
-            "child_ids|3|street",
-            "child_ids|3|country_id|code",
-            "child_ids|3|category_id|1|name",
-            "child_ids|3|category_id|2|name",
-            "child_ids|3|category_id|3|name",
-            "child_ids|3|category_id|4|name",
-            "child_ids|3|category_id|5|name",
-            "country_id|code",
-        ]
-        self.assertEqual(expected_header, headers)
+        self.assertEqual(self._get_expected_results()["expected_header_5"], headers)
 
     def test_get_data_to_export1(self):
         """
@@ -169,7 +179,7 @@ class PatternCaseExport:
             },
         ]
         for result, expected_result in zip(results, expected_results):
-            self.assertDictEqual(expected_result, result)
+            self._assert_result_expected_equal(expected_result, result)
 
     def test_get_data_to_export2(self):
         """
@@ -186,7 +196,7 @@ class PatternCaseExport:
         ]
         results = self._get_data(self.pattern_config_m2m, self.env.user)
         for result, expected_result in zip(results, expected_results):
-            self.assertDictEqual(expected_result, result)
+            self._assert_result_expected_equal(expected_result, result)
 
     def test_get_data_to_export3(self):
         """
@@ -209,7 +219,7 @@ class PatternCaseExport:
         ]
         results = self._get_data(self.pattern_config_m2m, self.env.user)
         for result, expected_result in zip(results, expected_results):
-            self.assertDictEqual(expected_result, result)
+            self._assert_result_expected_equal(expected_result, result)
 
     def test_get_data_to_export4(self):
         """
@@ -284,7 +294,7 @@ class PatternCaseExport:
         ]
         results = self._get_data(self.pattern_config_o2m, self.partners)
         for result, expected_result in zip(results, expected_results):
-            self.assertDictEqual(expected_result, result)
+            self._assert_result_expected_equal(expected_result, result)
 
     def test_get_data_to_export5(self):
         """
@@ -361,7 +371,7 @@ class PatternCaseExport:
 
         results = self._get_data(self.pattern_config_o2m, self.partners)
         for result, expected_result in zip(results, expected_results):
-            self.assertDictEqual(expected_result, result)
+            self._assert_result_expected_equal(expected_result, result)
 
     def test_get_data_to_export_is_key1(self):
         """

--- a/pattern_import_export_xlsx/tests/test_pattern_export.py
+++ b/pattern_import_export_xlsx/tests/test_pattern_export.py
@@ -19,6 +19,16 @@ CELL_VALUE_EMPTY = None
 
 
 class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
+    def _get_expected_results(self):
+        result = super()._get_expected_results()
+        for _, headers in result.items():
+            headers.insert(0, "#Error")
+        return result
+
+    def _assert_result_expected_equal(self, expected, actual):
+        del actual["#Error"]
+        super()._assert_result_expected_equal(expected, actual)
+
     @classmethod
     def _set_up_tab_names(cls):
         for el in ("ignore_one", "countries_1", "countries_2"):
@@ -152,14 +162,14 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
             "='{}'!$A$2:$A$1003".format(self.tab_name_countries_1),
         )
         self.assertEqual(
-            str(sheet_base.data_validations.dataValidation[0].cells), "D2:D1003"
+            str(sheet_base.data_validations.dataValidation[0].cells), "E2:E1003"
         )
         self.assertEqual(
             sheet_base.data_validations.dataValidation[1].formula1,
             "='Tags'!$A$2:$A$1007",
         )
         self.assertEqual(
-            str(sheet_base.data_validations.dataValidation[1].cells), "E2:E1003"
+            str(sheet_base.data_validations.dataValidation[1].cells), "F2:F1003"
         )
 
     def test_export_validators_simple_with_subpattern(self):
@@ -171,7 +181,7 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
         )
         self.assertEqual(
             str(sheet_base.data_validations.dataValidation[0].cells),
-            "F2:F1003 K2:K1003 P2:P1003 R2:R1003",
+            "G2:G1003 L2:L1003 Q2:Q1003 S2:S1003",
         )
         self.assertEqual(
             sheet_base.data_validations.dataValidation[1].formula1,
@@ -179,7 +189,7 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
         )
         self.assertEqual(
             str(sheet_base.data_validations.dataValidation[1].cells),
-            "G2:G1003 L2:L1003 Q2:Q1003",
+            "H2:H1003 M2:M1003 R2:R1003",
         )
 
     def test_export_validators_many2many(self):
@@ -190,7 +200,7 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
             sheet_base.data_validations.dataValidation[0].formula1,
             "='{}'!$A$2:$A$1003".format(self.tab_name_ignore_one),
         )
-        for idx, col_letter in enumerate(("C", "D", "E")):
+        for idx, col_letter in enumerate(("D", "E", "F")):
             self.assertEqual(
                 str(sheet_base.data_validations.dataValidation[0].cells.ranges[idx]),
                 "{0}2:{0}1003".format(col_letter),
@@ -215,5 +225,5 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
             "='{}'!$A$2:$A$1003".format(self.tab_name_ignore_one),
         )
         self.assertEqual(
-            str(sheet_base.data_validations.dataValidation[0].cells), "C2:C1003"
+            str(sheet_base.data_validations.dataValidation[0].cells), "D2:D1003"
         )

--- a/pattern_import_export_xlsx/tests/test_pattern_export.py
+++ b/pattern_import_export_xlsx/tests/test_pattern_export.py
@@ -84,11 +84,6 @@ class TestPatternExportExcel(PatternCaseExport, PatternCommon, SavepointCase):
                 cell_value = sheet.cell(row=itr_row, column=itr_col).value
                 self.assertEqual(cell_value, expected_cell_value)
 
-    def _helper_check_headers(self, sheet, expected_headers):
-        for itr_col, expected_cell_value in enumerate(expected_headers, start=1):
-            cell_value = sheet.cell(row=1, column=itr_col).value
-            self.assertEqual(cell_value, expected_cell_value)
-
     def test_export_tabs(self):
         wb = self._helper_get_resulting_wb(self.pattern_config, self.partners)
         sheets_name = [x.title for x in wb.worksheets]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,0 @@
-odoo14-addon-base_export_manager @ git+https://github.com/OCA/server-ux@refs/pull/227/head#subdirectory=setup/base_export_manager
-odoo14-addon-base_jsonify @ git+https://github.com/OCA/server-tools@refs/pull/1911/head#subdirectory=setup/base_jsonify
-odoo14-addon-web_notify @ git+https://github.com/OCA/web@refs/pull/1724/head#subdirectory=setup/web_notify
-odoo14-addon-base_sparse_field_list_support @ git+https://github.com/OCA/server-tools@refs/pull/1950/head#subdirectory=setup/base_sparse_field_list_support


### PR DESCRIPTION
When adding data validator ranges, inserting a column doesn't update the ranges.
Thus they break. This commit fixes this by always generating the error columns first and taking it into account when calculating every other cell position.
based on https://github.com/shopinvader/pattern-import-export/pull/81