### PR TITLE
[IMP] Add domain on subpatterns and refresh domain when possible

### DIFF
--- a/pattern_import_export/models/ir_exports_line.py
+++ b/pattern_import_export/models/ir_exports_line.py
@@ -141,6 +141,11 @@ class IrExportsLine(models.Model):
     @api.depends("name")
     def _compute_related_level_field(self):
         for export_line in self:
+            active_id = self.env.context.get("params") and self.env.context.get(
+                "params"
+            ).get("id")
+            if active_id:
+                export_line.export_id = active_id
             if export_line.name and export_line.export_id.model_id.model:
                 field, model, level = export_line._get_last_relation_field(
                     export_line.export_id.model_id.model, export_line.name

--- a/pattern_import_export/views/pattern_config.xml
+++ b/pattern_import_export/views/pattern_config.xml
@@ -139,6 +139,7 @@
                     'required': [('required_fields', 'ilike', 'sub_pattern_config_id')],
                     'readonly': [('hidden_fields', 'ilike', 'sub_pattern_config_id')],
                     'invisible': [('hidden_fields', 'ilike', 'sub_pattern_config_id')]}"
+                    domain="[('model_id', '=', related_model_id)]"
                 />
                 <field name="related_model_id" invisible="1" />
                 <field name="last_field_id" invisible="1" />


### PR DESCRIPTION
Fix applies to both tab selection and subpattern selection. Note that previously, the domain on select tab was broken (you had to save in form view to be able to choose any select tab in the UI