### PR TITLE
[FIX] not possible to choose id as "is key" since it is always a key …

### DIFF
--- a/pattern_import_export/views/pattern_config.xml
+++ b/pattern_import_export/views/pattern_config.xml
@@ -143,7 +143,7 @@
                 }</attribute>
             </xpath>
             <xpath expr="//field[@name='field4_id']" position="after">
-                <field name="is_key" />
+                <field name="is_key" attrs="{'readonly': [('name', '=', 'id')]}"/>
                 <field name="required_fields" invisible="1" />
                 <field name="hidden_fields" invisible="1" />
                 <field


### PR DESCRIPTION
…by default

Without this fix, a id field checked as is key will make the import fail