### PR TITLE
[FIX] avoid crash when changing a relational field to simple field

### DIFF
--- a/pattern_import_export/models/ir_exports_line.py
+++ b/pattern_import_export/models/ir_exports_line.py
@@ -61,7 +61,10 @@ class IrExportsLine(models.Model):
         if path:
             next_model = self.env[model]._fields[field]._related_comodel_name
             next_field = path.split("/", 1)[0]
-            if self.env[next_model]._fields[next_field]._related_comodel_name:
+            if (
+                next_model
+                and self.env[next_model]._fields[next_field]._related_comodel_name
+            ):
                 return self._get_last_relation_field(next_model, path, level=level + 1)
         return field, model, level
 


### PR DESCRIPTION
Example of crash before this fix : on res.partner, choose country_id as field1_id and code as field2_id then change field1_id for active
name field is not updated yet at the time it goes through _get_last_relation_field so odoo expected a relational field even though it is not anymore and crashes.