### PR TITLE
[14.0][FIX] pattern_import_export right for user to export

### DIFF
--- a/pattern_import_export/models/ir_exports.py
+++ b/pattern_import_export/models/ir_exports.py
@@ -8,7 +8,9 @@ class IrExports(models.Model):
     _inherit = "ir.exports"
 
     pattern_config_id = fields.Many2one(
-        "pattern.config", compute="_compute_pattern_config_id"
+        "pattern.config",
+        compute="_compute_pattern_config_id",
+        compute_sudo=True,
     )
 
     def _compute_pattern_config_id(self):


### PR DESCRIPTION
Actually, exporting a pattern requires write access on pattern.config but only pattern manager can, not pattern user. 
This PR add write right on pattern.config for pattern user group. 
UPDATE : remove the write right and add sudo right on export creation